### PR TITLE
#2 Add influxdb support

### DIFF
--- a/enviroplus_exporter.py
+++ b/enviroplus_exporter.py
@@ -166,7 +166,7 @@ def str_to_bool(value):
         return False
     elif value.lower() in {'true', 't', '1', 'yes', 'y'}:
         return True
-    raise ValueError(f'{value} is not a valid boolean value')
+    raise ValueError('{} is not a valid boolean value'.format(value))
 
 
 if __name__ == '__main__':

--- a/enviroplus_exporter.py
+++ b/enviroplus_exporter.py
@@ -4,6 +4,7 @@ import random
 import time
 import logging
 import argparse
+from threading import Thread
 
 from influxdb_client import InfluxDBClient
 from prometheus_client import start_http_server, Gauge, Histogram

--- a/enviroplus_exporter.py
+++ b/enviroplus_exporter.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+import os
 import random
 import time
 import logging
 import argparse
 
+from influxdb_client import InfluxDBClient
 from prometheus_client import start_http_server, Gauge, Histogram
 
 from bme280 import BME280
@@ -52,6 +54,15 @@ PM10 = Gauge('PM10', 'Particulate Matter of diameter less than 10 microns. Measu
 OXIDISING_HIST = Histogram('oxidising_measurements', 'Histogram of oxidising measurements', buckets=(0, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000, 65000, 70000, 75000, 80000, 85000, 90000, 100000))
 REDUCING_HIST = Histogram('reducing_measurements', 'Histogram of reducing measurements', buckets=(0, 100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1000000, 1100000, 1200000, 1300000, 1400000, 1500000))
 NH3_HIST = Histogram('nh3_measurements', 'Histogram of nh3 measurements', buckets=(0, 10000, 110000, 210000, 310000, 410000, 510000, 610000, 710000, 810000, 910000, 1010000, 1110000, 1210000, 1310000, 1410000, 1510000, 1610000, 1710000, 1810000, 1910000, 2000000))
+
+# Setup InfluxDB
+# You can generate an InfluxDB Token from the Tokens Tab in the InfluxDB Cloud UI
+INFLUXDB_URL = os.getenv('INFLUXDB_URL', '')
+INFLUXDB_TOKEN = os.getenv('INFLUXDB_TOKEN', '')
+INFLUXDB_BUCKETID = os.getenv('INFLUXDB_BUCKETID', '')
+INFLUXDB_TIME_BETWEEN_POSTS = int(os.getenv('INFLUXDB_TIME_BETWEEN_POSTS', '5'))
+influxdb_client = InfluxDBClient(url=INFLUXDB_URL, token=INFLUXDB_TOKEN)
+influxdb_api = influxdb_client.write_api()
 
 # Get the temperature of the CPU for compensation
 def get_cpu_temperature():
@@ -121,11 +132,45 @@ def get_particulates():
         PM10.set(pms_data.pm_ug_per_m3(10))
 
 
+def post_to_influxdb():
+    """Post all sensor data to InfluxDB"""
+    while True:
+        time.sleep(INFLUXDB_TIME_BETWEEN_POSTS)
+        name = 'enviroplus'
+        tag = ['location', 'adelaide']
+        fields = {}
+        sequence = []
+        epoch_time_now = round(time.time())
+        fields['temperature'] = TEMPERATURE.collect()[0].samples[0].value
+        fields['humidity'] = HUMIDITY.collect()[0].samples[0].value
+        fields['pressure'] = PRESSURE.collect()[0].samples[0].value
+        fields['oxidising'] = OXIDISING.collect()[0].samples[0].value
+        fields['reducing'] = REDUCING.collect()[0].samples[0].value
+        fields['nh3'] = NH3.collect()[0].samples[0].value
+        fields['lux'] = LUX.collect()[0].samples[0].value
+        fields['proximity'] = PROXIMITY.collect()[0].samples[0].value
+        fields['pm1'] = PM1.collect()[0].samples[0].value
+        fields['pm25'] = PM25.collect()[0].samples[0].value
+        fields['pm10'] = PM10.collect()[0].samples[0].value
+        for field_name in fields:
+            sequence.append(f'{name},{tag[0]}={tag[1]} {field_name}={fields[field_name]} {epoch_time_now}')
+        influxdb_api.write('bucketID', INFLUXDB_BUCKETID, sequence)
+
+
+def str_to_bool(value):
+    if value.lower() in {'false', 'f', '0', 'no', 'n'}:
+        return False
+    elif value.lower() in {'true', 't', '1', 'yes', 'y'}:
+        return True
+    raise ValueError(f'{value} is not a valid boolean value')
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-b", "--bind", metavar='ADDRESS', default='0.0.0.0', help="Specify alternate bind address [default: 0.0.0.0]")
     parser.add_argument("-p", "--port", metavar='PORT', default=8000, type=int, help="Specify alternate port [default: 8000]")
     parser.add_argument("-f", "--factor", metavar='FACTOR', type=float, help="The compensation factor to get better temperature results when the Enviro+ pHAT is too close to the Raspberry Pi board")
+    parser.add_argument("-i", "--influxdb", metavar='INFLUXDB', type=str_to_bool, default='false', help="Post sensor data to InfluxDB [default: false]")
     args = parser.parse_args()
 
     # Start up the server to expose the metrics.
@@ -135,8 +180,13 @@ if __name__ == '__main__':
     if args.factor:
         logging.info("Using compensating algorithm (factor={}) to account for heat leakage from Raspberry Pi board".format(args.factor))
 
-    logging.info("Listening on http://{}:{}".format(args.bind, args.port))
+    if args.influxdb:
+        # Post to InfluxDB on another thread
+        logging.info("Sensor data will be posted to InfluxDB every {} seconds".format(INFLUXDB_TIME_BETWEEN_POSTS))
+        influx_thread = Thread(target=post_to_influxdb)
+        influx_thread.start()
 
+    logging.info("Listening on http://{}:{}".format(args.bind, args.port))
 
     while True:
         get_temperature(args.factor)


### PR DESCRIPTION
Hi @tijmenvandenbrink,

I was wanting to test out integrating with [InfluxDB Cloud](https://www.influxdata.com/products/influxdb-cloud/), and so added that functionality to my [branch](https://github.com/sighmon/enviroplus_exporter/tree/add/2-influxdb-support).

Is it something you'd like to add? I realise it becomes less about Prometheus and more about a universal exporter.

Anyway, here's where I got with it:

* It reads the values set in the `while True:` loop every `INFLUXDB_TIME_BETWEEN_POSTS` seconds.
* Posts to InfluxDB on a separate thread so that it doesn't block the Prometheus exporter from updating.
* To enable it, pass in `-i true` or `--influxdb true` and set the following `ENV` variables:

```bash
export INFLUXDB_URL="https://location.gcp.cloud2.influxdata.com"
export INFLUXDB_TOKEN="your_token"
export INFLUXDB_ORG_ID="your_organisation_id"
export INFLUXDB_BUCKET="your_bucket_name"
export INFLUXDB_SENSOR_LOCATION="your_sensor_location"
export INFLUXDB_TIME_BETWEEN_POSTS="number_of_seconds_between_posts"
```

What do you think?

![enviro-plus-influxdb-cloud](https://user-images.githubusercontent.com/314298/78465851-da728180-7739-11ea-9a1f-7b56e8c5eb4c.png)
