### PR TITLE
Mention Python3 in Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ To get the prometheus enviroplus-exporter up and running I'm assuming you alread
 
 ### Prerequisites
 
-To run the enviroplus-exporter you need to have the enviroplus-python library by Pimoroni installed:
+- Python3
+- To run the enviroplus-exporter you need to have the enviroplus-python library by Pimoroni installed:
  
 ### One-line (Installs enviroplus-python library from GitHub)
 
@@ -111,7 +112,7 @@ sudo chown -R pi:pi /usr/src/enviroplus_exporter
 
 2.Install dependencies for enviroplus-exporter
 ```sh
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 3.Install as a Systemd service


### PR DESCRIPTION
A very small MR to mention Python3 in the README.
My (recently built) Pi didn't have it installed and it caused me to waste some time when the pip installation kept failing.
Took me a while to figure out it was because I was using Python 2.