### PR TITLE
Add Enviro support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IntelliJ IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ Jan 17 14:13:41 wall-e python[30373]: 2020-01-17 14:13:41.581 INFO     Listening
 sudo systemctl enable enviroplus-exporter
 ```
 
+## Enviro users
+
+If you are using an Enviro (not Enviro+) add `--enviro=true` to the command line (in the `/etc/systemd/system/enviroplus-exporter.service` file) then it won't try to use the missing sensors.
+
 <!-- USAGE EXAMPLES -->
 ## Usage
 

--- a/enviroplus_exporter.py
+++ b/enviroplus_exporter.py
@@ -247,7 +247,8 @@ if __name__ == '__main__':
     parser.add_argument("-b", "--bind", metavar='ADDRESS', default='0.0.0.0', help="Specify alternate bind address [default: 0.0.0.0]")
     parser.add_argument("-p", "--port", metavar='PORT', default=8000, type=int, help="Specify alternate port [default: 8000]")
     parser.add_argument("-f", "--factor", metavar='FACTOR', type=float, help="The compensation factor to get better temperature results when the Enviro+ pHAT is too close to the Raspberry Pi board")
-    parser.add_argument("-d", "--debug", metavar='DEBUG', type=str_to_bool, help="Turns on more vebose logging, showing sensor output and post responses [default: false]")
+    parser.add_argument("-e", "--enviro", metavar='ENVIRO', type=str_to_bool, help="Device is an Enviro (not Enviro+) so don't fetch data from gas and particulate sensors as they don't exist")
+    parser.add_argument("-d", "--debug", metavar='DEBUG', type=str_to_bool, help="Turns on more verbose logging, showing sensor output and post responses [default: false]")
     parser.add_argument("-i", "--influxdb", metavar='INFLUXDB', type=str_to_bool, default='false', help="Post sensor data to InfluxDB [default: false]")
     parser.add_argument("-l", "--luftdaten", metavar='LUFTDATEN', type=str_to_bool, default='false', help="Post sensor data to Luftdaten [default: false]")
     args = parser.parse_args()
@@ -281,8 +282,9 @@ if __name__ == '__main__':
         get_temperature(args.factor)
         get_pressure()
         get_humidity()
-        get_gas()
         get_light()
-        get_particulates()
+        if not args.enviro:
+            get_gas()
+            get_particulates()
         if DEBUG:
             logging.info('Sensor data: {}'.format(collect_all_data()))


### PR DESCRIPTION
The Enviro (not Enviro+) doesn't have Gas and Particulate sensors so
I've added a command-line option to ignore those sensors for that
device.