### PR TITLE
Feature/publish docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "master", "feature/publish-docker-image" ]
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,29 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2.2.0
+      with:
+        registry: https://ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v3
+    - name: Docker Setup Buildx
+      uses: docker/setup-buildx-action@v2.10.0
+      with:
+        platforms: linux/arm/v7,linux/arm64/v8
+    - name: Get Short SHA
+      id: shortsha
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Build container
+      run: docker buildx build -t ghcr.io/${USERNAME}/${REPOSITORY}:latest -t ghcr.io/${USERNAME}/${REPOSITORY}:${{ github.sha }} -t ghcr.io/${USERNAME}/${REPOSITORY}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,8 @@ name: Docker Image CI
 on:
   push:
     branches: [ "master", "feature/publish-docker-image" ]
-
+permissions: 
+  packages: write
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,4 +23,4 @@ jobs:
       id: shortsha
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Build container
-      run: docker buildx build -t ghcr.io/${{github.action_repository}}:latest -t ghcr.io/${{github.action_repository}}:${{ github.sha }} -t ghcr.io/${{github.action_repository}}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .
+      run: docker buildx build -t ghcr.io/${{github.repository}}:latest -t ghcr.io/${{github.repository}}:${{ github.sha }} -t ghcr.io/${{github.repository}}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,17 +8,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
+    - name: Docker Setup Buildx
+      uses: docker/setup-buildx-action@v2.10.0
+      with:
+        platforms: linux/arm/v7,linux/arm64/v8
     - name: Log in to the Container registry
       uses: docker/login-action@v2.2.0
       with:
         registry: https://ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v3
-    - name: Docker Setup Buildx
-      uses: docker/setup-buildx-action@v2.10.0
-      with:
-        platforms: linux/arm/v7,linux/arm64/v8
     - name: Get Short SHA
       id: shortsha
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,11 +3,12 @@ name: Docker Image CI
 on:
   push:
     branches: [ "master", "feature/publish-docker-image" ]
-permissions: 
-  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: 
+      packages: write
     steps:
     - uses: actions/checkout@v3
     - name: Docker Setup Buildx

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,3 +24,5 @@ jobs:
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Build container
       run: docker buildx build -t ghcr.io/${{github.repository}}:latest -t ghcr.io/${{github.repository}}:${{ github.sha }} -t ghcr.io/${{github.repository}}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .
+    - name: Build container
+      run: docker push -a ghcr.io/${{github.repository}}:${{ github.sha }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,6 +23,4 @@ jobs:
       id: shortsha
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Build container
-      run: docker buildx build -t ghcr.io/${{github.repository}}:latest -t ghcr.io/${{github.repository}}:${{ github.sha }} -t ghcr.io/${{github.repository}}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .
-    - name: Build container
-      run: docker push -a ghcr.io/${{github.repository}}:${{ github.sha }}
+      run: docker buildx build --push -t ghcr.io/${{github.repository}}:latest -t ghcr.io/${{github.repository}}:${{ github.sha }} -t ghcr.io/${{github.repository}}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,14 +2,11 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "feature/publish-docker-image" ]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Log in to the Container registry
       uses: docker/login-action@v2.2.0
@@ -26,4 +23,4 @@ jobs:
       id: shortsha
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Build container
-      run: docker buildx build -t ghcr.io/${USERNAME}/${REPOSITORY}:latest -t ghcr.io/${USERNAME}/${REPOSITORY}:${{ github.sha }} -t ghcr.io/${USERNAME}/${REPOSITORY}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .
+      run: docker buildx build -t ghcr.io/${{github.action_repository}}:latest -t ghcr.io/${{github.action_repository}}:${{ github.sha }} -t ghcr.io/${{github.action_repository}}:${{ steps.shortsha.outputs.sha_short }} --platform linux/arm/v7,linux/arm64/v8 .


### PR DESCRIPTION
This adds a github workflow to push a docker image to ghcr, on every push to the master branch. 

Due to the below permissions issue, I can't push the image to my own personal ghcr, but I tried the command locally and am 90% it'll work for you.

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#changing-the-permissions-in-a-forked-repository
